### PR TITLE
Allow argument to get a timed version of the server.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,7 @@ lazy val publishSettings = Seq(
       url("http://janbessai.github.io")
     )
   ),
+  version := "0.0.2",
   releaseEarlyWith := SonatypePublisher
 )
 


### PR DESCRIPTION
Using the jGitServer in integration tests in CI is quite hard, if the server is listening for a shutdown input. Depending of the environment the CI is running in, this input is always available. Therefore, the server shutdown, before the integration test can checkout the content.

Allowing to keep the server alive for a certain amount of time facilitates automated integration testing.